### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "jquery"
   ],
   "repository": "https://github.com/natelindev/react-use-hoverintent",
+  "homepage": "https://github.com/natelindev/react-use-hoverintent#readme",
+  "bugs": {
+    "url": "https://github.com/natelindev/react-use-hoverintent/issues"
+  },
   "license": "MIT",
   "author": "linlilulll@gmail.com",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to the repository README
- add npm `bugs.url` metadata pointing to the GitHub issue tracker

## Validation
- `node` package metadata assertion
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`